### PR TITLE
Fix problem when <i> class contains non-famfamfam classes

### DIFF
--- a/famfamfam-flags.css
+++ b/famfamfam-flags.css
@@ -5,8 +5,8 @@
  * <i class="famfamfam-flag-fr"> France</i>
  * <i class="famfamfam-flag-us"> United States</i>
  */
-
-[class*="famfamfam-flag"] {
+[class^="famfamfam-flag"],
+[class*=" famfamfam-flag"] {
   display: inline-block;
   width: 16px;
   height: 11px;

--- a/famfamfam-flags.css
+++ b/famfamfam-flags.css
@@ -6,7 +6,7 @@
  * <i class="famfamfam-flag-us"> United States</i>
  */
 
-[class^="famfamfam-flag"] {
+[class*="famfamfam-flag"] {
   display: inline-block;
   width: 16px;
   height: 11px;


### PR DESCRIPTION
For example this :
`<i class="any-class famfamfam-flag-us"></i>` didn't work.
